### PR TITLE
Removed line 898 to prevent crashing

### DIFF
--- a/eyetracker_calibrate/trackers/libeyelink.py
+++ b/eyetracker_calibrate/trackers/libeyelink.py
@@ -895,7 +895,6 @@ class libeyelink:
 					send_backdrop = el.bitmap2DBackdrop
 				else:
 					send_backdrop = el.bitmapBackdrop
-				send_backdrop = el.bitmap2DBackdrop
 				img = backdrop[0]
 				width = backdrop[1]
 				height = backdrop[2]


### PR DESCRIPTION
Line 898 was making the if hasattr(...) conditional irrelevant, by always calling bitmap2DBackdrop, which made an experiment to crash in absence of said function.

I'm not sure this code is even relevant nowadays, seeing as it's been 4 years since last update; but I found this fork I made some time ago and I thought there was no harm in opening my first pull request :)